### PR TITLE
PayPal provider integration (MVP) + security hardening

### DIFF
--- a/app/Application/Fulfillment/FulfillmentService.php
+++ b/app/Application/Fulfillment/FulfillmentService.php
@@ -38,8 +38,9 @@ final class FulfillmentService
      * Idempotent: if already fulfilled, returns success without side effects.
      *
      * @param array<string, mixed> $purchase Purchase record (from Purchase::create)
+     * @param string|null $customerEmail Email for delivery (not persisted, DSGVO)
      */
-    public function fulfill(array $purchase): FulfillmentResult
+    public function fulfill(array $purchase, ?string $customerEmail = null): FulfillmentResult
     {
         $purchaseId = $purchase['purchase_id'] ?? '';
         if ($purchaseId === '') {
@@ -89,7 +90,6 @@ final class FulfillmentService
 
             $downloadUrl = rtrim($this->baseUrl, '/') . $this->downloadPath . '?token=' . urlencode($tokenString);
 
-            $customerEmail = $purchase['customer_email'] ?? null;
             if (is_string($customerEmail) && $customerEmail !== '') {
                 $this->sendDeliveryEmail($customerEmail, $purchase, $productName, $licenseKey, $downloadUrl, $maxDownloads);
             }

--- a/app/Domain/Purchase/Purchase.php
+++ b/app/Domain/Purchase/Purchase.php
@@ -14,7 +14,7 @@ use RuntimeException;
  * - purchase_id: string (internal, stable)
  * - provider: string (e.g. "stripe")
  * - provider_event_id: string
- * - customer_email: ?string
+ * - customer_email_hash: ?string (sha256 of normalized email + pepper, DSGVO)
  * - product_id: string
  * - license_type: string
  * - amount: int (minor units, e.g. cents)
@@ -72,16 +72,16 @@ final class Purchase
             throw new RuntimeException('currency must be a non-empty string', 7);
         }
 
-        $customerEmail = $input['customer_email'] ?? null;
-        if ($customerEmail !== null && !is_string($customerEmail)) {
-            throw new RuntimeException('customer_email must be string or null', 8);
+        $customerEmailHash = $input['customer_email_hash'] ?? null;
+        if ($customerEmailHash !== null && !is_string($customerEmailHash)) {
+            throw new RuntimeException('customer_email_hash must be string or null', 8);
         }
 
         return [
             'purchase_id' => $purchaseId,
             'provider' => $provider,
             'provider_event_id' => $providerEventId,
-            'customer_email' => $customerEmail,
+            'customer_email_hash' => $customerEmailHash,
             'product_id' => $productId,
             'license_type' => $licenseType,
             'amount' => $amount,

--- a/app/Infrastructure/Purchases/PurchaseRepository.php
+++ b/app/Infrastructure/Purchases/PurchaseRepository.php
@@ -11,7 +11,7 @@ use RuntimeException;
  * Directories are created lazily (like WebhookEventStore).
  *
  * Purchase row schema:
- * - purchase_id, provider, provider_event_id, customer_email,
+ * - purchase_id, provider, provider_event_id, customer_email_hash,
  *   product_id, license_type, amount, currency, created_at, metadata
  */
 final class PurchaseRepository

--- a/cli/test_delivery_foundation.php
+++ b/cli/test_delivery_foundation.php
@@ -40,11 +40,15 @@ $fulfillmentRepo = new \App\Infrastructure\Fulfillment\FulfillmentRepository($fu
 echo "Delivery Foundation smoke test\n";
 echo "==============================\n";
 
+require_once $projectRoot . '/lib/Secrets.php';
+require_once $projectRoot . '/lib/Privacy.php';
+
 // 1. Create Purchase
+$foundationEmail = 'test@example.com';
 $purchase = \App\Domain\Purchase\Purchase::create([
     'provider' => 'stripe',
     'provider_event_id' => 'evt_test_' . time(),
-    'customer_email' => 'test@example.com',
+    'customer_email_hash' => \Privacy::hashCustomerEmail($foundationEmail, \Secrets::customerEmailPepper()),
     'product_id' => 'modular-web-core',
     'license_type' => 'single',
     'amount' => 1999,

--- a/cli/test_fulfillment.php
+++ b/cli/test_fulfillment.php
@@ -32,6 +32,7 @@ spl_autoload_register(static function (string $class) use ($projectRoot): void {
 });
 
 require_once $projectRoot . '/lib/Secrets.php';
+require_once $projectRoot . '/lib/Privacy.php';
 require_once $projectRoot . '/lib/Download/TokenService.php';
 require_once $projectRoot . '/lib/Download/TokenStoreJson.php';
 
@@ -73,10 +74,11 @@ $service = new \App\Application\Fulfillment\FulfillmentService(
     $subjectPrefix,
 );
 
+$testEmail = 'test@example.com';
 $purchase = \App\Domain\Purchase\Purchase::create([
     'provider' => 'test',
     'provider_event_id' => 'evt_fulfill_test_' . time(),
-    'customer_email' => 'test@example.com',
+    'customer_email_hash' => \Privacy::hashCustomerEmail($testEmail, \Secrets::customerEmailPepper()),
     'product_id' => 'starter_business_card',
     'license_type' => 'standard_license',
     'amount' => 7900,
@@ -91,7 +93,7 @@ echo "Purchase: {$purchase['purchase_id']}\n";
 echo "Product: {$purchase['product_id']}\n";
 echo "Mail mode: " . ($mailConfig['mode'] ?? 'pretend') . "\n\n";
 
-$result = $service->fulfill($purchase);
+$result = $service->fulfill($purchase, $testEmail);
 
 echo "Status: {$result->status}\n";
 echo "Success: " . ($result->success ? 'yes' : 'no') . "\n";

--- a/cli/test_webhook_fulfillment_sim.php
+++ b/cli/test_webhook_fulfillment_sim.php
@@ -31,6 +31,7 @@ spl_autoload_register(static function (string $class) use ($projectRoot): void {
 });
 
 require_once $projectRoot . '/lib/Secrets.php';
+require_once $projectRoot . '/lib/Privacy.php';
 require_once $projectRoot . '/lib/Download/TokenService.php';
 require_once $projectRoot . '/lib/Download/TokenStoreJson.php';
 
@@ -66,10 +67,11 @@ $fulfillmentService = new \App\Application\Fulfillment\FulfillmentService(
 );
 
 $eventId = 'evt_sim_' . time();
+$simEmail = 'sim-test@example.com';
 $purchase = \App\Domain\Purchase\Purchase::create([
     'provider' => 'stripe',
     'provider_event_id' => $eventId,
-    'customer_email' => 'sim-test@example.com',
+    'customer_email_hash' => \Privacy::hashCustomerEmail($simEmail, \Secrets::customerEmailPepper()),
     'product_id' => 'starter_business_card',
     'license_type' => 'standard_license',
     'amount' => 7900,
@@ -85,7 +87,7 @@ echo "Simulated Stripe event: {$eventId}\n";
 echo "Purchase: {$purchase['purchase_id']}\n";
 echo "Product: {$purchase['product_id']}\n\n";
 
-$result = $fulfillmentService->fulfill($purchase);
+$result = $fulfillmentService->fulfill($purchase, $simEmail);
 
 echo "Fulfillment: " . ($result->success ? 'OK' : 'FAILED') . "\n";
 if ($result->downloadUrl !== null && $result->downloadUrl !== '') {

--- a/config/app.php
+++ b/config/app.php
@@ -12,4 +12,6 @@ return [
     'download_path' => '/public/download.php',
     'checkout_success_path' => '/public/checkout/success.php',
     'checkout_cancel_path' => '/public/checkout/cancel.php',
+    'paypal_return_path' => '/public/paypal/return.php',
+    'paypal_cancel_path' => '/public/checkout/cancel.php',
 ];

--- a/config/paypal.php
+++ b/config/paypal.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * PayPal configuration.
+ * Client credentials and webhook ID. Sandbox for development.
+ */
+return [
+    'client_id' => '',
+    'secret' => '',
+    'sandbox' => true,
+    'webhook_id' => '',
+];

--- a/config/secrets.php.example
+++ b/config/secrets.php.example
@@ -10,4 +10,5 @@ return [
     'download_token_secret' => 'CHANGE_ME_TO_RANDOM_32_PLUS_BYTES_FOR_DEV',
     'stripe_webhook_secret' => 'whsec_...',
     'stripe_secret_key' => 'sk_test_...',
+    'customer_email_pepper' => 'CHANGE_ME_16_PLUS_BYTES',
 ];

--- a/lib/Payment/PayPalCheckoutService.php
+++ b/lib/Payment/PayPalCheckoutService.php
@@ -1,0 +1,217 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * PayPal Checkout Orders API v2.
+ * createOrder, captureOrder, verifyWebhook.
+ */
+final class PayPalCheckoutService
+{
+    private string $baseUrl;
+    private string $clientId;
+    private string $secret;
+    private string $webhookId;
+    private string $returnUrl;
+    private string $cancelUrl;
+
+    public function __construct(
+        string $clientId,
+        string $secret,
+        string $webhookId,
+        bool $sandbox,
+        string $returnUrl,
+        string $cancelUrl,
+    ) {
+        $this->clientId = $clientId;
+        $this->secret = $secret;
+        $this->webhookId = $webhookId;
+        $this->returnUrl = $returnUrl;
+        $this->cancelUrl = $cancelUrl;
+        $this->baseUrl = $sandbox ? 'https://api-m.sandbox.paypal.com' : 'https://api-m.paypal.com';
+    }
+
+    /**
+     * Create order and return approval URL.
+     * productId is resolved via catalog; custom_id stores product_id|license_type for webhook.
+     */
+    public function createOrder(string $productId, \App\Domain\Catalog\ProductCatalog $catalog): string
+    {
+        $product = $catalog->get($productId);
+        $licenseType = $product['license_type'] ?? '';
+        $amountMinor = (int) ($product['price_net_eur'] ?? 0);
+        $currency = 'eur';
+        $customId = $productId . '|' . $licenseType;
+        $value = number_format($amountMinor / 100, 2, '.', '');
+        $payload = [
+            'intent' => 'CAPTURE',
+            'purchase_units' => [
+                [
+                    'amount' => [
+                        'currency_code' => strtoupper($currency),
+                        'value' => $value,
+                    ],
+                    'custom_id' => $customId,
+                ],
+            ],
+            'application_context' => [
+                'return_url' => $this->returnUrl,
+                'cancel_url' => $this->cancelUrl,
+            ],
+        ];
+
+        $token = $this->getAccessToken();
+        $resp = $this->request('POST', $this->baseUrl . '/v2/checkout/orders', $token, $payload);
+
+        $links = $resp['links'] ?? [];
+        foreach ($links as $link) {
+            if (($link['rel'] ?? '') === 'approve') {
+                $url = $link['href'] ?? '';
+                if ($url !== '') {
+                    return $url;
+                }
+            }
+        }
+        throw new \RuntimeException('No approval URL in PayPal response');
+    }
+
+    /**
+     * Get order details (for custom_id from purchase_units).
+     *
+     * @return array<string, mixed>
+     */
+    public function getOrder(string $orderId): array
+    {
+        $token = $this->getAccessToken();
+        return $this->request(
+            'GET',
+            $this->baseUrl . '/v2/checkout/orders/' . urlencode($orderId),
+            $token,
+            null,
+        );
+    }
+
+    /**
+     * Capture order. Returns capture details.
+     *
+     * @return array<string, mixed>
+     */
+    public function captureOrder(string $orderId): array
+    {
+        $token = $this->getAccessToken();
+        $resp = $this->request(
+            'POST',
+            $this->baseUrl . '/v2/checkout/orders/' . urlencode($orderId) . '/capture',
+            $token,
+            (object) [],
+            ['Prefer' => 'return=representation'],
+        );
+        return is_array($resp) ? $resp : [];
+    }
+
+    /**
+     * Verify webhook signature via PayPal official endpoint.
+     * Fail closed: return false on any error or missing header.
+     *
+     * @see https://developer.paypal.com/docs/api/webhooks/v1/#verify-webhook-signature_post
+     *      POST /v1/notifications/verify-webhook-signature
+     *
+     * @param array<string, string> $headers PAYPAL-TRANSMISSION-ID, PAYPAL-TRANSMISSION-SIG, PAYPAL-TRANSMISSION-TIME, PAYPAL-AUTH-ALGO, PAYPAL-CERT-URL
+     */
+    public function verifyWebhook(array $headers, string $rawBody): bool
+    {
+        $transmissionId = $headers['PAYPAL-TRANSMISSION-ID'] ?? $headers['paypal-transmission-id'] ?? '';
+        $transmissionSig = $headers['PAYPAL-TRANSMISSION-SIG'] ?? $headers['paypal-transmission-sig'] ?? '';
+        $transmissionTime = $headers['PAYPAL-TRANSMISSION-TIME'] ?? $headers['paypal-transmission-time'] ?? '';
+        $authAlgo = $headers['PAYPAL-AUTH-ALGO'] ?? $headers['paypal-auth-algo'] ?? '';
+        $certUrl = $headers['PAYPAL-CERT-URL'] ?? $headers['paypal-cert-url'] ?? '';
+
+        if ($transmissionId === '' || $transmissionSig === '' || $transmissionTime === ''
+            || $authAlgo === '' || $certUrl === '' || $this->webhookId === '') {
+            return false;
+        }
+
+        $event = json_decode($rawBody, true);
+        if (!is_array($event)) {
+            return false;
+        }
+
+        $body = [
+            'auth_algo' => $authAlgo,
+            'cert_url' => $certUrl,
+            'transmission_id' => $transmissionId,
+            'transmission_sig' => $transmissionSig,
+            'transmission_time' => $transmissionTime,
+            'webhook_id' => $this->webhookId,
+            'webhook_event' => $event,
+        ];
+
+        try {
+            $resp = $this->request(
+                'POST',
+                $this->baseUrl . '/v1/notifications/verify-webhook-signature',
+                $this->getAccessToken(),
+                $body,
+            );
+        } catch (Throwable) {
+            return false;
+        }
+
+        return ($resp['verification_status'] ?? '') === 'SUCCESS';
+    }
+
+    private function getAccessToken(): string
+    {
+        $auth = base64_encode($this->clientId . ':' . $this->secret);
+        $ctx = stream_context_create([
+            'http' => [
+                'method' => 'POST',
+                'header' => "Authorization: Basic {$auth}\r\nContent-Type: application/x-www-form-urlencoded\r\n",
+                'content' => 'grant_type=client_credentials',
+                'ignore_errors' => true,
+            ],
+        ]);
+        $response = @file_get_contents($this->baseUrl . '/v1/oauth2/token', false, $ctx);
+        if ($response === false) {
+            throw new \RuntimeException('PayPal OAuth failed');
+        }
+        $data = json_decode($response, true);
+        $token = $data['access_token'] ?? '';
+        if ($token === '') {
+            throw new \RuntimeException('PayPal OAuth: no access token');
+        }
+        return $token;
+    }
+
+    /**
+     * @param array<string, string> $extraHeaders
+     */
+    private function request(string $method, string $url, string $token, mixed $body, array $extraHeaders = []): array
+    {
+        $headers = [
+            "Authorization: Bearer {$token}",
+            'Content-Type: application/json',
+        ];
+        foreach ($extraHeaders as $k => $v) {
+            $headers[] = "{$k}: {$v}";
+        }
+
+        $opts = [
+            'http' => [
+                'method' => $method,
+                'header' => implode("\r\n", $headers),
+                'ignore_errors' => true,
+            ],
+        ];
+        if ($method === 'POST' && $body !== (object) [] && $body !== []) {
+            $opts['http']['content'] = json_encode($body);
+        }
+
+        $response = @file_get_contents($url, false, stream_context_create($opts));
+        if ($response === false) {
+            throw new \RuntimeException('PayPal API request failed');
+        }
+        $decoded = json_decode($response, true);
+        return is_array($decoded) ? $decoded : [];
+    }
+}

--- a/lib/Privacy.php
+++ b/lib/Privacy.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * DSGVO helpers. Normalize and hash customer email for storage.
+ */
+final class Privacy
+{
+    /**
+     * SHA256 hash of normalized email + pepper. For Purchase persistence only.
+     */
+    public static function hashCustomerEmail(string $email, string $pepper): string
+    {
+        $normalized = strtolower(trim($email));
+        return hash('sha256', $normalized . $pepper);
+    }
+}

--- a/lib/Secrets.php
+++ b/lib/Secrets.php
@@ -141,6 +141,43 @@ final class Secrets
 
         return $key;
     }
+
+    /**
+     * Returns the pepper for customer email hashing (DSGVO).
+     * Used as sha256(normalized_email . pepper). Env CUSTOMER_EMAIL_PEPPER or config.
+     *
+     * @throws \RuntimeException if missing or too short (< 16 bytes)
+     */
+    public static function customerEmailPepper(): string
+    {
+        $pepper = getenv('CUSTOMER_EMAIL_PEPPER');
+        if ($pepper !== false && $pepper !== '' && strlen($pepper) >= 16) {
+            return $pepper;
+        }
+
+        $configPath = (defined('CORE_ROOT') ? CORE_ROOT : dirname(__DIR__)) . '/config/secrets.php';
+        if (!is_readable($configPath)) {
+            throw new \RuntimeException(
+                'customer_email_pepper missing. Set CUSTOMER_EMAIL_PEPPER or add to config/secrets.php',
+                13
+            );
+        }
+
+        $config = require $configPath;
+        if (!is_array($config)) {
+            throw new \RuntimeException('config/secrets.php must return an array', 14);
+        }
+
+        $pepper = $config['customer_email_pepper'] ?? '';
+        if (!is_string($pepper) || strlen($pepper) < 16) {
+            throw new \RuntimeException(
+                'customer_email_pepper missing or too short (min 16 bytes)',
+                15
+            );
+        }
+
+        return $pepper;
+    }
 }
 
 /**

--- a/public/buy_paypal.php
+++ b/public/buy_paypal.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * PayPal Checkout – Buy Flow.
+ * GET /buy_paypal.php?product_id=...
+ * Creates order, redirects to PayPal approval URL.
+ * No cookies, no sessions.
+ */
+
+define('CORE_ROOT', dirname(__DIR__));
+chdir(CORE_ROOT);
+
+spl_autoload_register(static function (string $class): void {
+    $prefix = 'App\\';
+    if (strncmp($class, $prefix, strlen($prefix)) !== 0) {
+        return;
+    }
+    $relative = substr($class, strlen($prefix));
+    $file = CORE_ROOT . '/app/' . str_replace('\\', '/', $relative) . '.php';
+    if (is_file($file)) {
+        require_once $file;
+    }
+});
+
+require_once CORE_ROOT . '/lib/Payment/PayPalCheckoutService.php';
+
+$method = $_SERVER['REQUEST_METHOD'] ?? '';
+if ($method !== 'GET') {
+    http_response_code(405);
+    header('Allow: GET');
+    header('Content-Type: text/plain');
+    echo 'Method not allowed';
+    exit;
+}
+
+$productId = isset($_GET['product_id']) ? trim((string) $_GET['product_id']) : '';
+
+function respond400(string $message): never
+{
+    http_response_code(400);
+    header('Content-Type: text/plain');
+    header('Cache-Control: no-store');
+    echo $message;
+    exit;
+}
+
+$config = require CORE_ROOT . '/config/paypal.php';
+if (!is_array($config)) {
+    http_response_code(500);
+    echo 'Configuration error';
+    exit;
+}
+
+$clientId = $config['client_id'] ?? '';
+$secret = $config['secret'] ?? '';
+$webhookId = $config['webhook_id'] ?? '';
+$sandbox = (bool) ($config['sandbox'] ?? true);
+
+if ($clientId === '' || $secret === '') {
+    http_response_code(500);
+    echo 'PayPal not configured';
+    exit;
+}
+
+$appConfig = require CORE_ROOT . '/config/app.php';
+$baseUrl = rtrim($appConfig['base_url'] ?? 'https://example.com', '/');
+$returnPath = $appConfig['paypal_return_path'] ?? '/public/paypal/return.php';
+$cancelPath = $appConfig['paypal_cancel_path'] ?? '/public/checkout/cancel.php';
+
+$productsPath = CORE_ROOT . '/config/products.php';
+$licenseTypesPath = CORE_ROOT . '/config/license-types.php';
+$catalog = new \App\Domain\Catalog\ProductCatalog($productsPath, $licenseTypesPath);
+
+$service = new PayPalCheckoutService(
+    $clientId,
+    $secret,
+    $webhookId,
+    $sandbox,
+    $baseUrl . $returnPath,
+    $baseUrl . $cancelPath,
+);
+
+try {
+    $approvalUrl = $service->createOrder($productId, $catalog);
+} catch (\App\Domain\Exceptions\CatalogException $e) {
+    respond400('Product not found');
+} catch (Throwable $e) {
+    http_response_code(500);
+    echo 'Checkout error';
+    exit;
+}
+
+http_response_code(303);
+header('Location: ' . $approvalUrl);
+header('Cache-Control: no-store');
+exit;

--- a/public/paypal/return.php
+++ b/public/paypal/return.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * PayPal return handler. User returns after approving payment.
+ * Captures order, shows "Payment processing".
+ * Fulfillment happens via webhook.
+ */
+
+define('CORE_ROOT', dirname(__DIR__, 2));
+chdir(CORE_ROOT);
+
+spl_autoload_register(static function (string $class): void {
+    $prefix = 'App\\';
+    if (strncmp($class, $prefix, strlen($prefix)) !== 0) {
+        return;
+    }
+    $relative = substr($class, strlen($prefix));
+    $file = CORE_ROOT . '/app/' . str_replace('\\', '/', $relative) . '.php';
+    if (is_file($file)) {
+        require_once $file;
+    }
+});
+
+require_once CORE_ROOT . '/lib/Payment/PayPalCheckoutService.php';
+
+$token = isset($_GET['token']) ? trim((string) $_GET['token']) : '';
+if ($token === '') {
+    http_response_code(400);
+    header('Content-Type: text/plain');
+    echo 'Missing token';
+    exit;
+}
+
+$config = require CORE_ROOT . '/config/paypal.php';
+if (!is_array($config)) {
+    http_response_code(500);
+    echo 'Configuration error';
+    exit;
+}
+
+$clientId = $config['client_id'] ?? '';
+$secret = $config['secret'] ?? '';
+$webhookId = $config['webhook_id'] ?? '';
+$sandbox = (bool) ($config['sandbox'] ?? true);
+
+if ($clientId === '' || $secret === '') {
+    http_response_code(500);
+    echo 'PayPal not configured';
+    exit;
+}
+
+$appConfig = require CORE_ROOT . '/config/app.php';
+$baseUrl = rtrim($appConfig['base_url'] ?? 'https://example.com', '/');
+$returnPath = $appConfig['paypal_return_path'] ?? '/public/paypal/return.php';
+$cancelPath = $appConfig['paypal_cancel_path'] ?? '/public/checkout/cancel.php';
+
+$service = new PayPalCheckoutService(
+    $clientId,
+    $secret,
+    $webhookId,
+    $sandbox,
+    $baseUrl . $returnPath,
+    $baseUrl . $cancelPath,
+);
+
+try {
+    $service->captureOrder($token);
+} catch (Throwable) {
+    // Idempotent: already-captured orders may throw; treat as success.
+}
+
+header('Content-Type: text/html; charset=utf-8');
+echo '<!DOCTYPE html><html><head><meta charset="utf-8"><title>Payment processing</title></head><body><p>Payment processing. You will receive your license and download link by email shortly.</p></body></html>';

--- a/public/webhook/paypal.php
+++ b/public/webhook/paypal.php
@@ -1,0 +1,252 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * PayPal webhook endpoint.
+ * POST only. Verifies signature, processes PAYMENT.CAPTURE.COMPLETED.
+ * Idempotency via PurchaseRepository.getByProviderEvent.
+ * Returns 200 on success/duplicate; 400 on signature failure; 500 on setup errors.
+ */
+
+$method = $_SERVER['REQUEST_METHOD'] ?? '';
+if ($method !== 'POST') {
+    http_response_code(405);
+    header('Allow: POST');
+    header('Content-Type: application/json');
+    echo json_encode(['error' => 'Method not allowed']);
+    exit;
+}
+
+define('CORE_ROOT', dirname(__DIR__, 2));
+chdir(CORE_ROOT);
+
+spl_autoload_register(static function (string $class): void {
+    $prefix = 'App\\';
+    if (strncmp($class, $prefix, strlen($prefix)) !== 0) {
+        return;
+    }
+    $relative = substr($class, strlen($prefix));
+    $file = CORE_ROOT . '/app/' . str_replace('\\', '/', $relative) . '.php';
+    if (is_file($file)) {
+        require_once $file;
+    }
+});
+
+require_once CORE_ROOT . '/lib/Secrets.php';
+require_once CORE_ROOT . '/lib/Download/TokenService.php';
+require_once CORE_ROOT . '/lib/Download/TokenStoreJson.php';
+require_once CORE_ROOT . '/lib/Payment/PayPalCheckoutService.php';
+
+$rawBody = (string) file_get_contents('php://input');
+
+function respond400(): never
+{
+    http_response_code(400);
+    header('Content-Type: application/json');
+    echo json_encode(['error' => 'Bad request']);
+    exit;
+}
+
+function respond500(): never
+{
+    http_response_code(500);
+    header('Content-Type: application/json');
+    echo json_encode(['error' => 'Internal server error']);
+    exit;
+}
+
+function respond200(): never
+{
+    http_response_code(200);
+    header('Content-Type: application/json');
+    echo json_encode(['received' => true]);
+    exit;
+}
+
+$config = require CORE_ROOT . '/config/paypal.php';
+if (!is_array($config)) {
+    respond500();
+}
+
+$clientId = $config['client_id'] ?? '';
+$secret = $config['secret'] ?? '';
+$webhookId = $config['webhook_id'] ?? '';
+$sandbox = (bool) ($config['sandbox'] ?? true);
+
+if ($clientId === '' || $secret === '' || $webhookId === '') {
+    respond500();
+}
+
+$appConfig = require CORE_ROOT . '/config/app.php';
+$baseUrl = rtrim($appConfig['base_url'] ?? 'https://example.com', '/');
+$returnPath = $appConfig['paypal_return_path'] ?? '/public/paypal/return.php';
+$cancelPath = $appConfig['paypal_cancel_path'] ?? '/public/checkout/cancel.php';
+
+$service = new PayPalCheckoutService(
+    $clientId,
+    $secret,
+    $webhookId,
+    $sandbox,
+    $baseUrl . $returnPath,
+    $baseUrl . $cancelPath,
+);
+
+$headers = [];
+foreach ($_SERVER as $k => $v) {
+    if (str_starts_with($k, 'HTTP_') && is_string($v)) {
+        $name = str_replace('_', '-', substr($k, 5));
+        $headers[$name] = $v;
+    }
+}
+
+if (!$service->verifyWebhook($headers, $rawBody)) {
+    respond400();
+}
+
+$event = json_decode($rawBody, true);
+if (!is_array($event)) {
+    respond400();
+}
+
+$eventType = $event['event_type'] ?? '';
+if ($eventType !== 'PAYMENT.CAPTURE.COMPLETED') {
+    respond200();
+}
+
+$eventId = $event['id'] ?? '';
+if ($eventId === '') {
+    respond400();
+}
+
+$storageRoot = CORE_ROOT . '/storage';
+$eventStore = new \App\Infrastructure\Webhooks\WebhookEventStore($storageRoot . '/webhooks/processed-events.json');
+if ($eventStore->has($eventId)) {
+    respond200();
+}
+
+$resource = $event['resource'] ?? null;
+if (!is_array($resource)) {
+    $eventStore->markProcessed($eventId, $eventType);
+    respond200();
+}
+
+$providerEventId = $eventId;
+$orderId = $resource['supplementary_data']['related_ids']['order_id'] ?? null;
+if (!is_string($orderId) || $orderId === '') {
+    $links = $resource['links'] ?? [];
+    foreach ($links as $link) {
+        if (($link['rel'] ?? '') === 'up') {
+            $href = $link['href'] ?? '';
+            if (preg_match('#/orders/([A-Z0-9]+)$#i', $href, $m)) {
+                $orderId = $m[1];
+                break;
+            }
+        }
+    }
+}
+
+$amountObj = $resource['amount'] ?? [];
+$amount = isset($amountObj['value']) ? (int) round((float) $amountObj['value'] * 100) : 0;
+$currency = $amountObj['currency_code'] ?? 'eur';
+$currency = is_string($currency) ? strtolower($currency) : 'eur';
+
+$customerEmail = null;
+$payer = $resource['payer'] ?? $event['resource']['payer'] ?? null;
+if (is_array($payer)) {
+    $email = $payer['email_address'] ?? null;
+    $customerEmail = is_string($email) ? $email : null;
+}
+
+$productId = null;
+$licenseType = null;
+
+if (is_string($orderId) && $orderId !== '') {
+    try {
+        $orderData = $service->getOrder($orderId);
+        $units = $orderData['purchase_units'] ?? [];
+        $customId = $units[0]['custom_id'] ?? null;
+        if (is_string($customId) && str_contains($customId, '|')) {
+            $parts = explode('|', $customId, 2);
+            $productId = trim($parts[0] ?? '');
+            $licenseType = trim($parts[1] ?? '');
+        }
+    } catch (Throwable) {
+        $productId = null;
+        $licenseType = null;
+    }
+}
+
+$purchaseRepo = new \App\Infrastructure\Purchases\PurchaseRepository($storageRoot . '/purchases/purchases.json');
+$fulfillmentRepo = new \App\Infrastructure\Fulfillment\FulfillmentRepository($storageRoot . '/fulfillment/fulfillment.json');
+$existingPurchase = $purchaseRepo->getByProviderEvent('paypal', $providerEventId);
+
+if ($productId === null || $productId === '' || $licenseType === null || $licenseType === '') {
+    if ($existingPurchase !== null) {
+        $purchaseId = $existingPurchase['purchase_id'];
+    } else {
+        $purchase = \App\Domain\Purchase\Purchase::create([
+            'provider' => 'paypal',
+            'provider_event_id' => $providerEventId,
+            'customer_email_hash' => $customerEmailHash,
+            'product_id' => '_invalid_',
+            'license_type' => '_unknown_',
+            'amount' => $amount,
+            'currency' => $currency,
+            'metadata' => [
+                'provider_ref' => $resource['id'] ?? null,
+                'order_id' => $orderId,
+                'invalid_reason' => 'custom_id not found in order',
+            ],
+        ]);
+        $purchaseRepo->create($purchase);
+        $purchaseId = $purchase['purchase_id'];
+    }
+    $fulfillmentRepo->setStatus($purchaseId, 'failed', [
+        'last_error_code' => 'invalid',
+        'last_error_message' => 'product_id/license_type not in order custom_id',
+    ]);
+    $eventStore->markProcessed($eventId, $eventType);
+    respond200();
+}
+
+$purchase = $existingPurchase;
+if ($purchase === null) {
+    $purchase = \App\Domain\Purchase\Purchase::create([
+        'provider' => 'paypal',
+        'provider_event_id' => $providerEventId,
+        'customer_email_hash' => $customerEmailHash,
+        'product_id' => $productId,
+        'license_type' => $licenseType,
+        'amount' => $amount,
+        'currency' => $currency,
+        'metadata' => array_filter([
+            'provider_ref' => $resource['id'] ?? null,
+            'order_id' => $orderId,
+        ]),
+    ]);
+    $purchaseRepo->create($purchase);
+}
+
+$mailConfig = require CORE_ROOT . '/config/mail.php';
+$productsPath = CORE_ROOT . '/config/products.php';
+$licenseTypesPath = CORE_ROOT . '/config/license-types.php';
+
+$fulfillmentService = new \App\Application\Fulfillment\FulfillmentService(
+    $fulfillmentRepo,
+    new \App\Domain\Catalog\ProductCatalog($productsPath, $licenseTypesPath),
+    new \TokenService(\Secrets::downloadTokenSecret()),
+    new \TokenStoreJson(CORE_ROOT . '/data/download_tokens.json'),
+    new \App\Infrastructure\License\LicenseKeyGenerator(),
+    \App\Infrastructure\Mail\MailerFactory::fromConfig($mailConfig),
+    $appConfig['base_url'] ?? 'https://example.com',
+    $appConfig['download_path'] ?? '/public/download.php',
+    CORE_ROOT . '/engine-version.json',
+    $mailConfig['support_contact'] ?? '',
+    $mailConfig['subject_prefix'] ?? '[Modular Web Core]',
+);
+
+$fulfillmentService->fulfill($purchase, $customerEmail);
+
+$eventStore->markProcessed($eventId, $eventType);
+respond200();

--- a/public/webhook/stripe.php
+++ b/public/webhook/stripe.php
@@ -34,6 +34,7 @@ spl_autoload_register(static function (string $class): void {
 });
 
 require_once CORE_ROOT . '/lib/Secrets.php';
+require_once CORE_ROOT . '/lib/Privacy.php';
 require_once CORE_ROOT . '/lib/Download/TokenService.php';
 require_once CORE_ROOT . '/lib/Download/TokenStoreJson.php';
 
@@ -245,7 +246,7 @@ $fulfillmentService = new \App\Application\Fulfillment\FulfillmentService(
     $mailConfig['subject_prefix'] ?? '[Modular Web Core]',
 );
 
-$fulfillmentService->fulfill($purchase);
+$fulfillmentService->fulfill($purchase, $customerEmail);
 
 $eventStore->markProcessed($eventId, $eventType);
 respond200();


### PR DESCRIPTION
Description

Add PayPal provider: buy_paypal flow + return/cancel + webhook handler

Webhook verification hardened via PayPal verify-webhook-signature endpoint

DSGVO: store only customer_email_hash (pepper-based), no plaintext email persistence

PayPal return page idempotent (no stack traces)

Tests updated accordingly

Notes

Requires CUSTOMER_EMAIL_PEPPER (>=16 bytes) via env or config/secrets.php (not committed)